### PR TITLE
Amend environment-setup to help with ns doctor failure on Mac M1 while testing cocoa pods

### DIFF
--- a/environment-setup.md
+++ b/environment-setup.md
@@ -269,9 +269,12 @@ softwareupdate --install-rosetta
 May need to install `ffi`
 
 ```cli
-gem install ffi
+sudo arch -x86_64 gem install ffi
 ```
-
+Then
+```cli
+arch -x86_64 pod install
+```
 ### Linux + Android
 
 You will need Node, NativeScript CLI (command line interface), Android Studio and a JDK (java development kit).


### PR DESCRIPTION
ns doctor can fail for a number of reasons.
This step will help when ffi gem is the wrong architecture.