### PR TITLE
feat: add device frame to screenshots

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -4,6 +4,7 @@ const {
 	markFlavorHeadings,
 	wrapFlavorContainersInTabs,
 	setupPrismCLILang,
+	createDeviceFrameContainer,
 } = require('./theme/nativescript-theme/plugins')
 
 setupPrismCLILang()
@@ -72,6 +73,9 @@ module.exports = {
 			md.use(...createFlavorContainer())
 			md.use(markFlavorHeadings)
 			md.use(wrapFlavorContainersInTabs)
+
+			// DeviceFrame related
+			md.use(...createDeviceFrameContainer())
 
 			// other.
 			md.use(codeBlocksPlugin)

--- a/.vitepress/theme/nativescript-theme/plugins/device-frame.js
+++ b/.vitepress/theme/nativescript-theme/plugins/device-frame.js
@@ -1,0 +1,48 @@
+'use strict'
+/**
+ * Adds device frames to images
+ *
+ * For example:
+ * /// frame ios
+ * <img src="ios_screenshot.png">
+ * ///
+ *
+ * /// frame android
+ * <img src="android_screenshot.png">
+ * ///
+ */
+Object.defineProperty(exports, '__esModule', { value: true })
+exports.createDeviceFrameContainer = void 0
+const container = require('markdown-it-container')
+const klass = 'frame'
+function createDeviceFrameContainer() {
+	return [
+		container,
+		klass,
+		{
+			marker: '/',
+			render(tokens, idx) {
+				const token = tokens[idx]
+				const info = token.info.trim().slice(klass.length).trim()
+				const deviceFrameStart = `
+        <div class="${info} device-frame">
+          <div class="${info} small-round-top"/>
+          <div class="${info} round-top-left"/>
+          <div class="${info} speaker"/>
+          <div class="${info} screenshot">
+        `
+				const deviceFrameEnd = `
+          </div>
+          <div class="${info} button"/>
+        </div>
+        `
+				if (token.nesting === 1) {
+					return deviceFrameStart
+				} else {
+					return deviceFrameEnd
+				}
+			},
+		},
+	]
+}
+exports.createDeviceFrameContainer = createDeviceFrameContainer

--- a/.vitepress/theme/nativescript-theme/plugins/index.js
+++ b/.vitepress/theme/nativescript-theme/plugins/index.js
@@ -1,6 +1,6 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
-exports.setupPrismCLILang = exports.wrapFlavorContainersInTabs = exports.markFlavorHeadings = exports.createFlavorContainer = exports.codeBlocksPlugin = void 0
+exports.setupPrismCLILang = exports.createDeviceFrameContainer = exports.wrapFlavorContainersInTabs = exports.markFlavorHeadings = exports.createFlavorContainer = exports.codeBlocksPlugin = void 0
 var code_blocks_1 = require('./code-blocks')
 Object.defineProperty(exports, 'codeBlocksPlugin', {
 	enumerable: true,
@@ -25,6 +25,13 @@ Object.defineProperty(exports, 'wrapFlavorContainersInTabs', {
 	enumerable: true,
 	get: function () {
 		return flavor_container_1.wrapFlavorContainersInTabs
+	},
+})
+var device_frame_1 = require('./device-frame')
+Object.defineProperty(exports, 'createDeviceFrameContainer', {
+	enumerable: true,
+	get: function () {
+		return device_frame_1.createDeviceFrameContainer
 	},
 })
 var prism_lang_cli_1 = require('./prism-lang-cli')

--- a/.vitepress/theme/nativescript-theme/styles.css
+++ b/.vitepress/theme/nativescript-theme/styles.css
@@ -3434,3 +3434,102 @@ svg.DocSearch-Hit-Select-Icon {
 .code-tab-container [class*='language-'] pre {
 	margin: 0px;
 }
+
+.ios.device-frame {
+	display: inline-block;
+	margin: 30px;
+	background-color: #f8fafc;
+	border: 1px solid #bae6fd;
+	padding: 0 10px 0 10px;
+	border-radius: 25px;
+	max-width: 100% !important;
+}
+
+.ios.device-frame > .screenshot > img {
+	max-width: 200px;
+	border: 1px solid #bae6fd;
+}
+
+.ios.device-frame > .small-round-top {
+	margin: 10px auto;
+	width: 5px;
+	height: 5px;
+	background-color: #bae6fd;
+	border-radius: 50%;
+}
+
+.ios.device-frame > .round-top-left {
+	float: left;
+	margin-left: 65px;
+	margin-top: -2px;
+	width: 9px;
+	height: 9px;
+	background-color: #bae6fd;
+	border-radius: 50%;
+}
+
+.ios.device-frame > .speaker {
+	margin: 15px auto;
+	margin-top: 10px;
+	width: 30px;
+	height: 5px;
+	background-color: #bae6fd;
+	border-radius: 3px;
+	margin-bottom: -0.5em;
+}
+
+.ios.device-frame > .button {
+	border-radius: 50%;
+	margin: 10px auto;
+	width: 30px;
+	height: 30px;
+	border: 2px solid #bae6fd;
+	background: none !important;
+	margin-top: -1em;
+}
+
+.android.device-frame {
+	display: inline-block;
+	margin: 30px;
+	background-color: #f8fafc;
+	border: 1px solid #bae6fd;
+	padding: 0 10px 0 10px;
+	border-radius: 12px;
+	max-width: 100% !important;
+}
+
+.android.device-frame > .screenshot > img {
+	max-width: 223px;
+	border: 1px solid #bae6fd;
+}
+
+.android.device-frame > .small-round-top {
+	margin: 10px auto;
+	width: 0px;
+	height: 0px;
+	background-color: #bae6fd;
+	border-radius: 50%;
+}
+
+.android.device-frame > .round-top-left {
+	float: right;
+	margin-right: 10px;
+	margin-top: 3px;
+	width: 9px;
+	height: 9px;
+	background-color: #bae6fd;
+	border-radius: 50%;
+}
+
+.android.device-frame > .speaker {
+	margin: 15px auto;
+	width: 30px;
+	height: 5px;
+	background-color: #bae6fd;
+	border-radius: 3px;
+	margin-bottom: -1em;
+}
+
+.android.device-frame > .button {
+	display: none;
+}

--- a/introduction.md
+++ b/introduction.md
@@ -58,8 +58,13 @@ Here are some of the default templates you may want to try:
 A basic template with a single page and no custom styles.
 
 <!-- TODO: make nicer images -->
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-ios.png" style="height:400px;">
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-android.png" style="height:400px;">
+
+/// frame ios
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-ios.png">
+///
+/// frame android
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-android.png">
+///
 
 To use, run:
 
@@ -72,8 +77,13 @@ ns create myCoolApp --template @nativescript/template-blank
 A simple template with a side drawer.
 
 <!-- TODO: make nicer images -->
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-drawer-navigation/tools/assets/appTemplate-ios.png" style="height:400px">
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-drawer-navigation/tools/assets/appTemplate-android.png" style="height:400px">
+
+/// frame ios
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-drawer-navigation/tools/assets/appTemplate-ios.png">
+///
+/// frame android
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-drawer-navigation/tools/assets/appTemplate-android.png">
+///
 
 To use, run:
 
@@ -86,8 +96,13 @@ ns create myCoolApp --template @nativescript/template-blank
 A simple template with multiple tabs.
 
 <!-- TODO: make nicer images -->
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-tab-navigation/tools/assets/phone-tab-ios.png" style="height:400px">
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-tab-navigation/tools/assets/phone-tab-android.png" style="height:400px">
+
+/// frame ios
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-tab-navigation/tools/assets/appTemplate-ios.png">
+///
+/// frame android
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-tab-navigation/tools/assets/appTemplate-android.png">
+///
 
 To use, run:
 
@@ -98,9 +113,12 @@ ns create myCoolApp --template @nativescript/template-tab-navigation
 ### List and Details
 
 A simple template with a ListView and a details screen.
-
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-master-detail/tools/assets/phone-masterDetail-ios.png" style="height:400px">
-<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-master-detail/tools/assets/phone-masterDetail-detail-ios.png" style="height:400px">
+/// frame ios
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-master-detail/tools/assets/appTemplate-ios.png">
+///
+/// frame android
+<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-master-detail/tools/assets/appTemplate-android.png">
+///
 
 To use, run:
 


### PR DESCRIPTION
Wrapping screenshot images with a device frame on `ios` and `android` with
```
/// frame ios

<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-ios.png">

///

/// frame android

<img src="https://raw.githubusercontent.com/NativeScript/nativescript-app-templates/master/packages/template-blank/tools/assets/appTemplate-android.png">

///
```

would render them like this:

<img width="1160" alt="Screenshot 2021-04-20 at 15 18 38" src="https://user-images.githubusercontent.com/33330538/115402510-c043fe00-a1eb-11eb-8d28-8f4f895e609c.png">

Related to: https://github.com/NativeScript/nativescript-website/pull/4#issue-619320781
