### PR TITLE
fix link to ImageSource class

### DIFF
--- a/plugins/social-share.md
+++ b/plugins/social-share.md
@@ -25,7 +25,7 @@ import * as SocialShare from "@nativescript/social-share";
 
 ### shareImage(ImageSource image, [optional] String subject)
 
-The `shareImage()` method expects an [`ImageSource`](http://docs.nativescript.org/ApiReference/image-source/ImageSource.html) object. The code below loads an image from the app and invokes the share widget with it:
+The `shareImage()` method expects an [`ImageSource`](/api-reference/classes/imagesource.html) object. The code below loads an image from the app and invokes the share widget with it:
 
 ```JavaScript
 // ------------ JavaScript ------------------


### PR DESCRIPTION
Fixes the link to the ImageSource class previous one did not work on even v7/v6 doc site.