### PR TITLE
fix ImageSource link use full url

### DIFF
--- a/plugins/social-share.md
+++ b/plugins/social-share.md
@@ -25,7 +25,7 @@ import * as SocialShare from "@nativescript/social-share";
 
 ### shareImage(ImageSource image, [optional] String subject)
 
-The `shareImage()` method expects an [`ImageSource`](/api-reference/classes/imagesource.html) object. The code below loads an image from the app and invokes the share widget with it:
+The `shareImage()` method expects an [`ImageSource`](https://docs.nativescript.org/api-reference/classes/imagesource.html) object. The code below loads an image from the app and invokes the share widget with it:
 
 ```JavaScript
 // ------------ JavaScript ------------------


### PR DESCRIPTION
Looks like you have to use a full url to link to the api docs, rather than relative.
If you use relative even though the link is correct it doesn't render.