### PR TITLE
fix: handle invalid characters in plugin names

### DIFF
--- a/scripts/plugin-scraper.mjs
+++ b/scripts/plugin-scraper.mjs
@@ -30,7 +30,7 @@ async function main() {
 
 			const headerSnippet = [
 				`---`,
-				`title: ${plugin.name}`,
+				`title: ${JSON.stringify(plugin.name)}`,
 				`link: ${url}`,
 				`---`,
 			].join('\n')


### PR DESCRIPTION
Fixes this error:
<img width="974" alt="Screenshot 2021-10-11 at 16 24 14" src="https://user-images.githubusercontent.com/33330538/136806882-b9b0096a-a788-4119-b4ae-c26730c55309.png">
