### PR TITLE
feat(plugins): transform note styles

### DIFF
--- a/scripts/plugin-scraper.mjs
+++ b/scripts/plugin-scraper.mjs
@@ -80,16 +80,38 @@ async function main() {
 	}
 }
 
-function transformNoteStyle(data) {
-	// Transforms note styles for vitepress
-	// The notes should look like the following to match the regex
-	// > **Note:** Example note
-	const noteStringRegex = /(\> \*\*.*\*\*( |:))(.)*\n/ig;
-	const noteKeywordRegex = /(\> \*\*.*\*\*( |: ))/ig;
+function transformNoteStyle(content) {
+	// transforms note styles for vitepress
+	const debug = false;
+	const NOTE_RE = /^>\s+\*{2}([^\*]+)\*{2}:?[^\S\r\n]+(.+(?:\n>.*)*)/gim;
+	let match_;
+	const containerTypeMap = {
+		'note': 'tip',
+		'warning': 'warning',
+	}
+		
+	while(match_ = NOTE_RE.exec(content)) {
+		let [match, title, cont] = match_;
+		
+		debug && console.log({
+			match, title, cont
+		})
+		
+		// normalize title
+		title = title.replace(/:/g, '');
+		
+		// replace "> " from multiline quotes
+		cont = cont.replace(/^>\s*/gim, '');
+		
+		// generate replacement
+		let containerType = containerTypeMap[title.toLowerCase()] ?? 'tip';
+		const replacement = `:::${containerType} ${title}\n\n${cont}\n\n:::`;
+		
+		// replace the match with the replacement
+		content = content.replace(match, replacement);
+	  }
 
-	return data.replace(noteStringRegex, ":::tip Note\n$&:::\n")
-			  .replace(noteKeywordRegex, "")
-			  .trim();
+	return content;
 }
 
 main()

--- a/scripts/plugin-scraper.mjs
+++ b/scripts/plugin-scraper.mjs
@@ -46,7 +46,7 @@ async function main() {
 			// save the file
 			fse.outputFileSync(
 				`./${plugin.link}.md`,
-				`${headerSnippet}\n\n${repoSnippet}\n\n${data.trim()}`
+				`${headerSnippet}\n\n${repoSnippet}\n\n${transformNoteStyle(data)}`
 			)
 			log(chalk.green(`File saved for plugin: ${plugin.name}`))
 		}
@@ -78,6 +78,16 @@ async function main() {
 		log(chalk.red(error), error)
 		process.exit()
 	}
+}
+
+function transformNoteStyle(data) {
+	// Transforms note styles for vitepress
+	const noteStringRegex = /(\> \*\*.*\*\*( |:))(.)*\n/ig;
+	const noteKeywordRegex = /(\> \*\*.*\*\*( |: ))/ig;
+
+	return data.replace(noteStringRegex, ":::tip Note\n$&:::\n")
+			  .replace(noteKeywordRegex, "")
+			  .trim();
 }
 
 main()

--- a/scripts/plugin-scraper.mjs
+++ b/scripts/plugin-scraper.mjs
@@ -82,6 +82,8 @@ async function main() {
 
 function transformNoteStyle(data) {
 	// Transforms note styles for vitepress
+	// The notes should look like the following to match the regex
+	// > **Note:** Example note
 	const noteStringRegex = /(\> \*\*.*\*\*( |:))(.)*\n/ig;
 	const noteKeywordRegex = /(\> \*\*.*\*\*( |: ))/ig;
 


### PR DESCRIPTION
This enhancement will wrap the notes in the plugins docs with `:::tip Note ::::`, so the plugins will follow the main docs styling without messing up the original `README.md`

Before:
<img width="828" alt="Screenshot 2021-10-15 at 10 17 23" src="https://user-images.githubusercontent.com/33330538/137455306-3022f5cd-d1b1-4ca0-b2a3-8f42ecf2de3d.png">

After
<img width="871" alt="Screenshot 2021-10-15 at 10 19 19" src="https://user-images.githubusercontent.com/33330538/137455761-a4416be8-1c3a-46e7-835d-aa7e421b8bc9.png">
:
