### PR TITLE
fix: UI listview table

### DIFF
--- a/ui-and-styling.md
+++ b/ui-and-styling.md
@@ -2833,14 +2833,14 @@ export class ListViewTipsComponent implements OnInit {
 
 #### Properties
 
-| Name                    | Type                   | Description                                                                       |
-| ----------------------- | ---------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `items`                 | `Array<any>`           | `ItemsSource`                                                                     | Gets or set the items collection of the `ListView`. The items property can be set to an array or an object defining length and getItem(index) method. |
-| `itemTemplateSelector`  | `function`             | A function that returns the appropriate key template based on the data item.      |
-| `itemTemplates`         | `Array<KeyedTemplate>` | Gets or set the list of item templates for the item template selector.            |
-| `separatorColor`        | `string`               | `Color`                                                                           | Gets or set the items separator line color of the ListView.                                                                                           |
-| `rowHeight`             | `Length`               | Gets or set row height of the ListView.                                           |
-| `iosEstimatedRowHeight` | `Length`               | Gets or set the estimated height of rows in the ListView. Default value: **44px** |
+| Name                    | Type                          | Description                                                                                                                                           |
+| ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `items`                 | `Array<any>` \| `ItemsSource` | Gets or set the items collection of the `ListView`. The items property can be set to an array or an object defining length and getItem(index) method. |
+| `itemTemplateSelector`  | `function`                    | A function that returns the appropriate ket template based on the data item.                                                                          |
+| `itemTemplates`         | `Array<KeyedTemplate>`        | Gets or set the list of item templates for the item template selector.                                                                                |
+| `separatorColor`        | `string` \| `Color`           | Gets or set the items separator line color of the ListView.                                                                                           |
+| `rowHeight`             | `Length`                      | Gets or set row height of the ListView.                                                                                                               |
+| `iosEstimatedRowHeight` | `Length`                      | Gets or set the estimated height of rows in the ListView. Default value: **44px**                                                                     |
 
 ///
 

--- a/ui-and-styling.md
+++ b/ui-and-styling.md
@@ -2836,7 +2836,7 @@ export class ListViewTipsComponent implements OnInit {
 | Name                    | Type                          | Description                                                                                                                                           |
 | ----------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `items`                 | `Array<any>` \| `ItemsSource` | Gets or set the items collection of the `ListView`. The items property can be set to an array or an object defining length and getItem(index) method. |
-| `itemTemplateSelector`  | `function`                    | A function that returns the appropriate ket template based on the data item.                                                                          |
+| `itemTemplateSelector`  | `function`                    | A function that returns the appropriate key template based on the data item.                                                                          |
 | `itemTemplates`         | `Array<KeyedTemplate>`        | Gets or set the list of item templates for the item template selector.                                                                                |
 | `separatorColor`        | `string` \| `Color`           | Gets or set the items separator line color of the ListView.                                                                                           |
 | `rowHeight`             | `Length`                      | Gets or set row height of the ListView.                                                                                                               |


### PR DESCRIPTION
There seems to be a typo in the table on the Angular section of the ListView causing it to not render correctly (https://docs.nativescript.org/ui-and-styling.html#listview)

**Before**

![Screen Shot 2021-10-19 at 5 00 33 PM](https://user-images.githubusercontent.com/20136906/137888210-7f6f8a40-b714-448b-84b4-e12477683a9e.png)

**After**

![Screen Shot 2021-10-19 at 5 10 48 PM](https://user-images.githubusercontent.com/20136906/137889807-a62625c4-127b-4e83-a6a7-8e580dc2760d.png)


