### PR TITLE
fixed typing capitalization error

### DIFF
--- a/interaction.md
+++ b/interaction.md
@@ -1499,7 +1499,7 @@ export function showAlertDialog() {
 
 ### Action Dialog
 
-An Action Dialog will require a particular activity from the user. The action method accepts multiple parameters or an ActionOptions object with keys title, message, cancelBUttonText, actions, and cancelable(Android only property).
+An Action Dialog will require a particular activity from the user. The action method accepts multiple parameters or an ActionOptions object with keys title, message, cancelButtonText, actions, and cancelable(Android only property).
 
 ```ts
 import { Dialogs } from '@nativescript/core'


### PR DESCRIPTION
I was reading up on dialogs this past week and came across this capitalization error. I imagine this was just a typing oversight at some point when inputting the info. It is just one letter but I have been referencing this section of the docs and so I thought I should update it!