### PR TITLE
Add missing methods in example for extending Android Activity

### DIFF
--- a/advanced-concepts.md
+++ b/advanced-concepts.md
@@ -183,6 +183,7 @@ class Activity extends androidx.appcompat.app.AppCompatActivity {
   private _callbacks: AndroidActivityCallbacks
 
   public onCreate(savedInstanceState: android.os.Bundle): void {
+    Application.android.init(this.getApplication())
     // Set the isNativeScriptActivity in onCreate (as done in the original NativeScript activity code)
     // The JS constructor might not be called because the activity is created from Android.
     this.isNativeScriptActivity = true
@@ -191,6 +192,10 @@ class Activity extends androidx.appcompat.app.AppCompatActivity {
     }
 
     this._callbacks.onCreate(this, savedInstanceState, this.getIntent(), super.onCreate)
+  }
+
+  public onNewIntent(intent: android.content.Intent): void {
+    this._callbacks.onNewIntent(this, intent, super.setIntent, super.onNewIntent)
   }
 
   public onSaveInstanceState(outState: android.os.Bundle): void {
@@ -207,6 +212,10 @@ class Activity extends androidx.appcompat.app.AppCompatActivity {
 
   public onDestroy(): void {
     this._callbacks.onDestroy(this, super.onDestroy)
+  }
+
+  public onPostResume(): void {
+    this._callbacks.onPostResume(this, super.onPostResume)
   }
 
   public onBackPressed(): void {


### PR DESCRIPTION
This adds / documents some missing methods that are implemented in the default activity from [Nativescript Core](https://github.com/NativeScript/NativeScript/blob/0d4ccba60aae9a340fcee28bc0880dead353c799/packages/core/ui/frame/activity.android.ts).

I had a problem when using the [firebase-messaging](https://github.com/NativeScript/firebase/blob/main/packages/firebase-messaging/README.md) module and the `onNotificationTap` handler. That method was never called, when the app was in the background, but it worked, when the app was exited / terminated.

It seemed that the extra data of the Android Intent was empty under this condition and this is used in the firebase module.  Adding these two methods to the activity, fixed the issue for me. I hope this fix saves someone else a little bit of debugging.

I am a little bit unsure about line 186, but that line also exists in the default activity.