### PR TITLE
fix: blog post links

### DIFF
--- a/advanced-concepts.md
+++ b/advanced-concepts.md
@@ -368,7 +368,7 @@ In order to satisfy the above constraints the developer has to:
 Swift classes need to be accessible from the Objective-C runtime in order to be used from NativeScript. This can be done by using the _@objc_ attribute or by inheriting _NSObject_.
 :::
 
-For a detailed walkthrough on how to use native iOS source code in NativeScript [here](https://www.nativescript.org/blog/adding-objective-c-code-to-a-nativescript-app).
+For a detailed walkthrough on how to use native iOS source code in NativeScript [here](https://blog.nativescript.org/adding-objective-c-code-to-a-nativescript-app/).
 
 ### Objective C Example
 

--- a/performance.md
+++ b/performance.md
@@ -427,7 +427,7 @@ Because heap snapshots completely avoid the need to parse and execute the vast m
 
 <img src="https://github.com/NativeScript/docs/raw/master/docs/img/best-practices/android-start-up-3.gif" style="height: 450px;">
 
-> **NOTE**: For a far more technical explanation of how V8 heap snapshots work in NativeScript, and how you can configure and optimize the snapshots, check out [this article on the NativeScript blog](https://www.nativescript.org/blog/improving-app-startup-time-on-android-with-webpack-v8-heap-snapshot).
+> **NOTE**: For a far more technical explanation of how V8 heap snapshots work in NativeScript, and how you can configure and optimize the snapshots, check out [this article on the NativeScript blog](https://blog.nativescript.org/improving-app-startup-time-on-android-with-webpack-v8-heap-snapshot).
 
 <h2 id="summary">Summary</h2>
 


### PR DESCRIPTION
Issue: 
In Advanced Concepts, section about Adding ObjectC/Swift Code(https://docs.nativescript.org/advanced-concepts.html#adding-objectivec-swift-code), the link to a blog post goes to a dead end. This is the link in the docs currently: https://www.nativescript.org/blog/adding-objective-c-code-to-a-nativescript-app

Solution:
Update link to correct url: https://blog.nativescript.org/adding-objective-c-code-to-a-nativescript-app/. Also, I updated link in performance page (Step 2, right above summary: https://docs.nativescript.org/performance.html#benefits-from-using-lazy-loading )that had a similar incorrect blog url.