### PR TITLE
Clarify code sample

### DIFF
--- a/plugins/firebase-crashlytics.md
+++ b/plugins/firebase-crashlytics.md
@@ -76,7 +76,7 @@ As Crashlytics will be sending certain information regarding the user, users may
 ```ts
 import { firebase } from '@nativescript/firebase-core'
 
-firebase().crashlytics().setCrashlyticsCollectionEnabled(true)
+firebase().crashlytics().setCrashlyticsCollectionEnabled(false)
 ```
 
 ## License


### PR DESCRIPTION
As per Firebase docs, if a user wants to opt out of crashlytics, you would set the value in setCrashlyticsCollectionEnabled to false, not true.

https://firebase.google.com/docs/reference/swift/firebasecrashlytics/api/reference/Classes/Crashlytics#setcrashlyticscollectionenabled_: