### PR TITLE
fix: update documentation pages with improvements

### DIFF
--- a/advanced-concepts.md
+++ b/advanced-concepts.md
@@ -135,7 +135,7 @@ module.exports = env => {
 
   webpack.chainWebpack(config => {
     if (webpack.Utils.platform.getPlatformName() === 'android') {
-      // make sure the path to the applicatioon.android.(js|ts)
+      // make sure the path to the application.android.(js|ts)
       // is relative to the webpack.config.js
       // you may need to use `./app/application.android if
       // your app source is located inside the ./app folder.
@@ -660,7 +660,7 @@ Blocks in Objective-C, especially blocks that are closures, need to be properly 
 
 #### CoreFoundation Objects
 
-iOS contains both an Objective-C standard library (the Foundation framework) and a pure C standard library (Core Foundation). Core Foundation is modeled after Foundation to a great extent and implements a limited object model. Data types such as CFDictionaryRef and CFBundleRef are Core Foundation objects. Core Foundation objects are retained and released just like Objective-C objects, using the CFRetain and CFRelease functions. NativeScript implements automatic memory management for functions that are annotated as returning a retained Core Foundation object. For those that are not annotated, NativeScript returns an Unmanaged type that wraps the Core Foundation instance. This makes you partially responsible for keeping the instance allive. You could either
+iOS contains both an Objective-C standard library (the Foundation framework) and a pure C standard library (Core Foundation). Core Foundation is modeled after Foundation to a great extent and implements a limited object model. Data types such as CFDictionaryRef and CFBundleRef are Core Foundation objects. Core Foundation objects are retained and released just like Objective-C objects, using the CFRetain and CFRelease functions. NativeScript implements automatic memory management for functions that are annotated as returning a retained Core Foundation object. For those that are not annotated, NativeScript returns an Unmanaged type that wraps the Core Foundation instance. This makes you partially responsible for keeping the instance alive. You could either
 
 - Call takeRetainedValue() which would return managed reference to the wrapped instance, decrementing the reference count while doing so
 - Call takeUnretainedValue() which would return managed reference to the wrapped instance _without_ decrementing the reference count
@@ -1539,7 +1539,7 @@ Kotlin's [properties](https://kotlinlang.org/docs/reference/properties.html#prop
 ```js
 var kotlinClass = new com.example.KotlinClassWithStringProperty()
 
-var propertyValue = kotlinClass.getStringPropert()
+var propertyValue = kotlinClass.getStringProperty()
 kotlinClass.setStringProperty('example')
 
 propertyValue = kotlinClass.stringProperty
@@ -1801,7 +1801,7 @@ This problem is easily solved by not specifying a --compileSdk flag and using th
 ##### Implication B: Building against higher API level.
 
 What happens when an application is built with higher API level(e.g. 23), but runs on a device with a lower API level(e.g. 20)?
-First the metadata is built for API level 23. If the javascript code calls a method introduced after API level 20 the Android runtime will try to call this method because it will recognize it in the metadata, but when the actual native call is made on the lower level device, an exception will be trown because this method won't be present on the device.
+First the metadata is built for API level 23. If the javascript code calls a method introduced after API level 20 the Android runtime will try to call this method because it will recognize it in the metadata, but when the actual native call is made on the lower level device, an exception will be thrown because this method won't be present on the device.
 
 This problem is solved by detecting the API level at run-time and using the available API.
 
@@ -2320,7 +2320,7 @@ class MainActivity extends android.app.Activity {
 
 ### Metadata Filtering
 
-By default NativeScript includes all supported entities in the metadata. This allows app and plugin authors to freely call any native API from JavaScript. While it is benefitial during development, in some cases having metadata for all the APIs is undesirable. There could be security implications involved (mentioning names of entities that shouldn't be known in the metadata binary files for example); performance could be degraded at runtime (due to larger metabase which has to be consulted when an unknown entry is encountered or at startup); or app size could increase due to unnecessary metadata which is never used.
+By default NativeScript includes all supported entities in the metadata. This allows app and plugin authors to freely call any native API from JavaScript. While it is beneficial during development, in some cases having metadata for all the APIs is undesirable. There could be security implications involved (mentioning names of entities that shouldn't be known in the metadata binary files for example); performance could be degraded at runtime (due to larger metabase which has to be consulted when an unknown entry is encountered or at startup); or app size could increase due to unnecessary metadata which is never used.
 
 To give developers control over what to be included or not in the generated metadata there's support for black and whitelisting symbols by their native name.
 

--- a/app-resources.md
+++ b/app-resources.md
@@ -31,7 +31,7 @@ App_Resources/
 └─ ... more
 ```
 
-Values can be overriden on specific API levels by making the changes in the corresponding directories.
+Values can be overridden on specific API levels by making the changes in the corresponding directories.
 
 ### Adding native code to an application
 
@@ -120,7 +120,7 @@ To change the default color of the status bar, edit the `ns_primaryDark` color i
 
 :::tip Note
 
-The color will be applied on API21+ since lower API leves do not support custom status bar colors\*.
+The color will be applied on API21+ since lower API levels do not support custom status bar colors\*.
 
 :::
 
@@ -137,7 +137,7 @@ Various native elements have an accent color, which can be changed by setting th
 
 :::tip Note
 
-The color will be applied on API21+ since lower API leves do not support custom accent colors.
+The color will be applied on API21+ since lower API levels do not support custom accent colors.
 
 :::
 

--- a/development-workflow.md
+++ b/development-workflow.md
@@ -276,7 +276,7 @@ Visit the official sites for details on how to install and use these emulators.
 
 The iOS simulator emulates iOS devices on Macs. The following documentation is a quick way to get the iOS simulator set up. For more information, see [Apple's documentation](https://developer.apple.com/library/archive/documentation/IDEs/Conceptual/simulator_help_topics/Chapter/Chapter.html).
 
-#### Running on iOS Simualators
+#### Running on iOS Simulators
 
 On a mac if you have XCode installed with the proper tools, executing `ns run ios` from your terminal will launch the Simulator program with a default device. Alternatively, you can open the Simulator program on your mac, select which device(s) you want to open by navigating to `File -> Open Simulator` and choosing the device to launch. Then execute `ns run ios` and the NativeScript app will launch on the open simulator(s).
 
@@ -752,7 +752,7 @@ A package manager is a piece of software that lets you manage the external code,
 
 #### Supported package managers
 
-NativeScript CLI allows you to configure the package manager used when working with dependencies. When you change the defaultly used `npm` package manager, CLI will use the newly set package manager for all operations it executes related to project dependencies, for example, project creation, managing dependencies, etc.
+NativeScript CLI allows you to configure the package manager used when working with dependencies. When you change the default `npm` package manager, CLI will use the newly set package manager for all operations it executes related to project dependencies, for example, project creation, managing dependencies, etc.
 
 NativeScript CLI supports three package managers:
 
@@ -1035,6 +1035,6 @@ If you’re a WebStorm user, check out this [popular community-written plugin](h
 - [Code Samples](https://market.nativescript.org/?tab=samples&framework=all_frameworks&category=all_samples)
   - The NativeScript team provides a collection of high-quality code samples you can add to your applications. Perusing the code samples is a great way to get familiar with what NativeScript can do, as well as find the code you can use on your next app.
 - [Books and Videos](https://www.nativescript.org/books-and-videos)
-  - Browse our collection of NativeScript books and videos, including the free-to-download NativeScript book by Nick and Mike Brainstein.
+  - Browse our collection of NativeScript books and videos, including the free-to-download NativeScript book by Nick and Mike Branstein.
 - [NativeScripting](https://nativescripting.com/)
   - The third-party NativeScripting site has many video courses to teach you everything you need to know about NativeScript, including a collection of free courses to help you get started.

--- a/interaction.md
+++ b/interaction.md
@@ -2241,7 +2241,7 @@ It can be set to one of the following:
 - `AccessibilityRole.Adjustable` Element that can be "adjusted" (e.g. a slider).
 - `AccessibilityRole.Button` Element that should be treated as a button.
 - `AccessibilityRole.Checkbox` Element that represents a checkbox which can be checked or unchecked.
-- `AccessibilityRole.Header` Eement that acts as a header for a section.
+- `AccessibilityRole.Header` Element that acts as a header for a section.
 - `AccessibilityRole.Image` Element that should be treated as an image.
 - `AccessibilityRole.ImageButton` Element that should be treated as a button and is also an image.
 - `AccessibilityRole.KeyboardKey` Element that acts as a keyboard key.


### PR DESCRIPTION
Update some general documentation pages with minor improvements for fixing typos, coding sample errors, and names to improve the overall readability and maintain consistency.